### PR TITLE
chore(rebrand): metadata & NOTICE (no code changes)

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,9 @@
+# NOTICE
+
+This repository is an **independent fork** of upstream Uniswap code and is **not affiliated with or endorsed by Uniswap**.
+
+- Upstream source: git@github.com:Uniswap/smart-order-router.git
+- Copyrights and licenses remain with their respective owners.
+- See `LICENSE` for full licensing terms of this repository. Some upstream components may be under different licenses; consult upstream for details.
+
+This fork primarily changes branding and build/release metadata at this stage. Functional changes (if any) will be documented in release notes and pull requests.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Independent fork** — not affiliated with Uniswap. See NOTICE.md.
+
 # Uniswap Smart Order Router
 
 This repository contains routing logic for the Uniswap V3 protocol.

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@uniswap/smart-order-router",
   "version": "4.22.20",
-  "description": "Uniswap Smart Order Router",
+  "description": "Primea fork — independent fork of upstream Uniswap repo",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
   "module": "build/module/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Uniswap/smart-order-router.git"
+    "url": "git+ssh://git@github.com/primeanetwork/smart-order-router.git"
   },
   "license": "GPL",
   "keywords": [],
@@ -124,5 +124,9 @@
   },
   "oclif": {
     "commands": "./cli/commands"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/primeanetwork/smart-order-router/issues"
+  },
+  "homepage": "https://github.com/primeanetwork/smart-order-router#readme"
 }


### PR DESCRIPTION
Adds `NOTICE.md`, injects an in-repo banner in `README.md`, and updates `package.json` metadata fields to point to `primeanetwork/smart-order-router`. **No product code changes.**